### PR TITLE
クライアント関係の検証作成

### DIFF
--- a/internal/payment/domain/repository_interface.go
+++ b/internal/payment/domain/repository_interface.go
@@ -1,0 +1,9 @@
+package domain
+
+type CompanyRepository interface {
+	IsClientOfCompany(companyId CompanyId, clientId ClientId) (bool, error)
+}
+
+type UserRepository interface {
+	FindByUserId(userId UserId) (User, error)
+}

--- a/internal/payment/domain/user.go
+++ b/internal/payment/domain/user.go
@@ -1,0 +1,6 @@
+package domain
+
+type User struct {
+	UserId    UserId
+	CompanyId CompanyId
+}

--- a/internal/payment/imock/mock_company_repository.go
+++ b/internal/payment/imock/mock_company_repository.go
@@ -1,0 +1,16 @@
+package imock
+
+import (
+	"upsidr-coding-test/internal/payment/domain"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockCompanyRepository struct {
+	mock.Mock
+}
+
+func (m *MockCompanyRepository) IsClientOfCompany(companyId domain.CompanyId, clientId domain.ClientId) (bool, error) {
+	args := m.Called(companyId, clientId)
+	return args.Bool(0), args.Error(1)
+}

--- a/internal/payment/imock/mock_user_repository.go
+++ b/internal/payment/imock/mock_user_repository.go
@@ -1,0 +1,16 @@
+package imock
+
+import (
+	"upsidr-coding-test/internal/payment/domain"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockUserRepository struct {
+	mock.Mock
+}
+
+func (m *MockUserRepository) FindByUserId(userId domain.UserId) (domain.User, error) {
+	args := m.Called(userId)
+	return args.Get(0).(domain.User), args.Error(1)
+}

--- a/internal/payment/service/client_verification.go
+++ b/internal/payment/service/client_verification.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"upsidr-coding-test/internal/payment/domain"
+)
+
+type ClientVerificationService struct {
+	logger      Logger
+	companyRepo domain.CompanyRepository
+	userRepo    domain.UserRepository
+}
+
+func NewClientVerificationService(
+	logger Logger,
+	companyRepo domain.CompanyRepository,
+	userRepo domain.UserRepository,
+) ClientVerificationService {
+	return ClientVerificationService{
+		logger:      logger,
+		companyRepo: companyRepo,
+		userRepo:    userRepo,
+	}
+}
+
+func (s *ClientVerificationService) VerifyRelationshipWithClient(userId string, clientId string) error {
+	clId, err := domain.NewClientId(clientId)
+	if err != nil {
+		s.logger.Error(err)
+		return err
+	}
+	uId, err := domain.NewUserId(userId)
+	if err != nil {
+		s.logger.Error(err)
+		return err
+	}
+	user, err := s.userRepo.FindByUserId(uId)
+	if err != nil {
+		s.logger.Error(err)
+		return ErrorClientRelationVerificationFailed
+	}
+	ok, err := s.companyRepo.IsClientOfCompany(user.CompanyId, clId)
+	if err != nil {
+		s.logger.Error(err)
+		return ErrorClientRelationVerificationFailed
+	}
+	if !ok {
+		return ErrorClientNotRelatedWithCompany
+	}
+	return nil
+}

--- a/internal/payment/service/error.go
+++ b/internal/payment/service/error.go
@@ -1,0 +1,8 @@
+package service
+
+import "errors"
+
+var (
+	ErrorClientNotRelatedWithCompany      error = errors.New("client is not related with the company")
+	ErrorClientRelationVerificationFailed error = errors.New("an error occurred while verifying the client relationship. please try again.")
+)

--- a/internal/payment/service/logger_interface.go
+++ b/internal/payment/service/logger_interface.go
@@ -1,0 +1,5 @@
+package service
+
+type Logger interface {
+	Error(i ...interface{})
+}

--- a/internal/payment/service/t_client_verification_test.go
+++ b/internal/payment/service/t_client_verification_test.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"errors"
+	"testing"
+	"upsidr-coding-test/internal/payment/domain"
+	"upsidr-coding-test/internal/payment/imock"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestVerifyRelationshipWithClient(t *testing.T) {
+	// uId, _ := domain.NewUserId("user1")
+
+	type args struct {
+		userId   string
+		clientId string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		mock    func(logger *imock.MockLogger, userRepo *imock.MockUserRepository, companyRepo *imock.MockCompanyRepository)
+		wantErr error
+	}{
+		{
+			name: "ユーザーとクライアントの関係性が正しい",
+			args: args{userId: "user1", clientId: "client1"},
+			mock: func(logger *imock.MockLogger, userRepo *imock.MockUserRepository, companyRepo *imock.MockCompanyRepository) {
+				comId, _ := domain.NewCompanyId("company1")
+				logger.On("Error", nil).Return()
+				userRepo.On("FindByUserId", mock.AnythingOfType("domain.UserId")).Return(domain.User{CompanyId: comId}, nil)
+				companyRepo.On("IsClientOfCompany", mock.AnythingOfType("domain.CompanyId"), mock.AnythingOfType("domain.ClientId")).Return(true, nil)
+			},
+			wantErr: nil,
+		},
+		{
+			name: "関係性の確認中にDBエラーが発生",
+			args: args{userId: "user1", clientId: "client1"},
+			mock: func(logger *imock.MockLogger, userRepo *imock.MockUserRepository, companyRepo *imock.MockCompanyRepository) {
+				comId, _ := domain.NewCompanyId("company1")
+				logger.On("Error", mock.Anything).Return()
+				userRepo.On("FindByUserId", mock.AnythingOfType("domain.UserId")).Return(domain.User{CompanyId: comId}, nil)
+				companyRepo.On("IsClientOfCompany", mock.AnythingOfType("domain.CompanyId"), mock.AnythingOfType("domain.ClientId")).Return(false, errors.New("db error"))
+			},
+			wantErr: ErrorClientRelationVerificationFailed,
+		},
+		{
+			name: "ユーザーがクライアントとの関係性がない",
+			args: args{userId: "user1", clientId: "client1"},
+			mock: func(logger *imock.MockLogger, userRepo *imock.MockUserRepository, companyRepo *imock.MockCompanyRepository) {
+				comId, _ := domain.NewCompanyId("company1")
+				logger.On("Error", nil).Return()
+				userRepo.On("FindByUserId", mock.AnythingOfType("domain.UserId")).Return(domain.User{CompanyId: comId}, nil)
+				companyRepo.On("IsClientOfCompany", mock.AnythingOfType("domain.CompanyId"), mock.AnythingOfType("domain.ClientId")).Return(false, nil)
+			},
+			wantErr: ErrorClientNotRelatedWithCompany,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := new(imock.MockLogger)
+			userRepo := new(imock.MockUserRepository)
+			companyRepo := new(imock.MockCompanyRepository)
+			tt.mock(logger, userRepo, companyRepo)
+			service := NewClientVerificationService(logger, companyRepo, userRepo)
+			err := service.VerifyRelationshipWithClient(tt.args.userId, tt.args.clientId)
+
+			assert.Equal(t, tt.wantErr, err)
+			userRepo.AssertExpectations(t)
+			companyRepo.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
## 概要

クライアントとの関係を検証するサービスを作成。
今回の実装は、**ユーザーがクライアントに対してなんらかの操作を行った際に、その関係を検証**するもの。
請求書の発行以外今は思いつかないが、請求書の発行操作は企業と対象企業の関係があって初めて発行されるもの。（だと思っている）
なので、その二社間の関係をUserIDとClientIDから検証できるサービスを作成。
CompanyIDではなく、UserIDなのは自身が所属している企業はデータモデル上特定できるため。
またAPIの想定なのでヘッダーに付与するトークンからユーザーが特定でき、つながりで所属企業も特定が可能なため。