### PR TITLE
請求書発行処理作成

### DIFF
--- a/internal/payment/domain/repository_interface.go
+++ b/internal/payment/domain/repository_interface.go
@@ -1,5 +1,13 @@
 package domain
 
+type UnitOfWorkExecutor interface {
+	Exec() error
+}
+
+type InvoiceRepository interface {
+	Store(invoice Invoice) error
+}
+
 type CompanyRepository interface {
 	IsClientOfCompany(companyId CompanyId, clientId ClientId) (bool, error)
 }

--- a/internal/payment/imock/mock_executor.go
+++ b/internal/payment/imock/mock_executor.go
@@ -1,0 +1,12 @@
+package imock
+
+import "github.com/stretchr/testify/mock"
+
+type MockExecutor struct {
+	mock.Mock
+}
+
+func (m *MockExecutor) Exec() error {
+	args := m.Called()
+	return args.Error(0)
+}

--- a/internal/payment/imock/mock_invoice_repository.go
+++ b/internal/payment/imock/mock_invoice_repository.go
@@ -1,0 +1,16 @@
+package imock
+
+import (
+	"upsidr-coding-test/internal/payment/domain"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockInvoiceRepository struct {
+	mock.Mock
+}
+
+func (m *MockInvoiceRepository) Store(inv domain.Invoice) error {
+	args := m.Called(inv)
+	return args.Error(0)
+}

--- a/internal/payment/imock/mock_logger.go
+++ b/internal/payment/imock/mock_logger.go
@@ -1,0 +1,11 @@
+package imock
+
+import "github.com/stretchr/testify/mock"
+
+type MockLogger struct {
+	mock.Mock
+}
+
+func (m *MockLogger) Error(args ...interface{}) {
+	m.Called(args...)
+}

--- a/internal/payment/usecase/dto.go
+++ b/internal/payment/usecase/dto.go
@@ -1,0 +1,10 @@
+package usecase
+
+import "time"
+
+type InvoiceCreateDTO struct {
+	UserId        string
+	ClientId      string
+	PaymentAmount int
+	DueAt         time.Time
+}

--- a/internal/payment/usecase/error.go
+++ b/internal/payment/usecase/error.go
@@ -1,0 +1,7 @@
+package usecase
+
+import "errors"
+
+var (
+	ErrorFailedToIssueInvoice error = errors.New("failed to issue the invoice. please try again.")
+)

--- a/internal/payment/usecase/invoice.go
+++ b/internal/payment/usecase/invoice.go
@@ -1,0 +1,68 @@
+package usecase
+
+import (
+	"time"
+	"upsidr-coding-test/internal/payment/domain"
+	"upsidr-coding-test/internal/payment/service"
+
+	"github.com/google/uuid"
+)
+
+type InvoiceUseCase struct {
+	logger                    service.Logger
+	invoiceRepo               domain.InvoiceRepository
+	userRepo                  domain.UserRepository
+	executor                  domain.UnitOfWorkExecutor
+	clientVerificationService *service.ClientVerificationService
+}
+
+func NewInvoiceUseCase(
+	logger service.Logger,
+	invoiceRepo domain.InvoiceRepository,
+	userRepo domain.UserRepository,
+	executor domain.UnitOfWorkExecutor,
+	clientVerificationService *service.ClientVerificationService,
+) InvoiceUseCase {
+	return InvoiceUseCase{
+		logger:                    logger,
+		invoiceRepo:               invoiceRepo,
+		userRepo:                  userRepo,
+		executor:                  executor,
+		clientVerificationService: clientVerificationService,
+	}
+}
+
+func (u *InvoiceUseCase) Create(dto InvoiceCreateDTO) (domain.Invoice, error) {
+	if err := u.clientVerificationService.VerifyRelationshipWithClient(dto.UserId, dto.ClientId); err != nil {
+		return domain.Invoice{}, err
+	}
+	uId, err := domain.NewUserId(dto.UserId)
+	if err != nil {
+		return domain.Invoice{}, err
+	}
+
+	usr, err := u.userRepo.FindByUserId(uId)
+	if err != nil {
+		u.logger.Error(err)
+		return domain.Invoice{}, nil
+	}
+
+	invoice, err := domain.NewInvoice(time.Now(), dto.DueAt, uuid.NewString(), usr.CompanyId.Value(), dto.ClientId, dto.PaymentAmount)
+	if err != nil {
+		u.logger.Error(err)
+		return domain.Invoice{}, err
+	}
+	if err := invoice.CalculateInvoiceAmount(); err != nil {
+		u.logger.Error(err)
+		return domain.Invoice{}, err
+	}
+	if err := u.invoiceRepo.Store(invoice); err != nil {
+		u.logger.Error(err)
+		return domain.Invoice{}, ErrorFailedToIssueInvoice
+	}
+	if err := u.executor.Exec(); err != nil {
+		u.logger.Error(err)
+		return domain.Invoice{}, ErrorFailedToIssueInvoice
+	}
+	return invoice, nil
+}

--- a/internal/payment/usecase/t_invoice_test.go
+++ b/internal/payment/usecase/t_invoice_test.go
@@ -1,0 +1,221 @@
+package usecase
+
+import (
+	"testing"
+	"time"
+	"upsidr-coding-test/internal/payment/domain"
+	"upsidr-coding-test/internal/payment/imock"
+	"upsidr-coding-test/internal/payment/service"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvoiceUseCase_Create(t *testing.T) {
+	now := time.Now()
+
+	type args struct {
+		dto InvoiceCreateDTO
+	}
+
+	tests := []struct {
+		name string
+		args args
+		mock func(
+			logger *imock.MockLogger,
+			invoiceRepo *imock.MockInvoiceRepository,
+			companyRepo *imock.MockCompanyRepository,
+			userRepo *imock.MockUserRepository,
+			executor *imock.MockExecutor,
+		)
+		want    func() domain.Invoice
+		wantErr error
+	}{
+		{
+			name: "正常に請求書を作成",
+			args: args{
+				dto: InvoiceCreateDTO{
+					UserId:        "user1",
+					ClientId:      "client1",
+					PaymentAmount: 10000,
+					DueAt:         now.AddDate(0, 0, 1),
+				},
+			},
+			mock: func(
+				logger *imock.MockLogger,
+				invoiceRepo *imock.MockInvoiceRepository,
+				companyRepo *imock.MockCompanyRepository,
+				userRepo *imock.MockUserRepository,
+				executor *imock.MockExecutor,
+			) {
+				comId, _ := domain.NewCompanyId("company1")
+				logger.On("Error", mock.Anything).Return()
+				invoiceRepo.On("Store", mock.AnythingOfType("domain.Invoice")).Return(nil)
+				companyRepo.On("IsClientOfCompany", mock.AnythingOfType("domain.CompanyId"), mock.AnythingOfType("domain.ClientId")).Return(true, nil)
+				userRepo.On("FindByUserId", mock.AnythingOfType("domain.UserId")).Return(domain.User{CompanyId: comId}, nil)
+				executor.On("Exec").Return(nil)
+			},
+			want: func() domain.Invoice {
+				clId, _ := domain.NewClientId("client1")
+				paymentAmount, _ := domain.NewPaymentAmount(10000)
+				fee := domain.NewFee(paymentAmount)
+				tax := domain.NewTax(fee)
+				invoiceAmount, _ := domain.NewInvoiceAmount(paymentAmount, fee, tax)
+				issDate, _ := domain.NewIssueDate(now)
+				dueDate, _ := domain.NewDueDate(now.AddDate(0, 0, 1), issDate)
+				return domain.Invoice{
+					ClientId:      clId,
+					IssueDate:     issDate,
+					PaymentAmount: paymentAmount,
+					Fee:           fee,
+					Tax:           tax,
+					InvoiceAmount: invoiceAmount,
+					DueDate:       dueDate,
+				}
+			},
+			wantErr: nil,
+		},
+		{
+			name: "支払い金額が0円",
+			args: args{
+				dto: InvoiceCreateDTO{
+					UserId:        "user1",
+					ClientId:      "client1",
+					PaymentAmount: 0,
+					DueAt:         now.AddDate(0, 0, 1),
+				},
+			},
+			mock: func(
+				logger *imock.MockLogger,
+				invoiceRepo *imock.MockInvoiceRepository,
+				companyRepo *imock.MockCompanyRepository,
+				userRepo *imock.MockUserRepository,
+				executor *imock.MockExecutor,
+			) {
+				comId, _ := domain.NewCompanyId("company1")
+				logger.On("Error", mock.Anything).Return()
+				invoiceRepo.On("Store", mock.AnythingOfType("domain.Invoice")).Return(nil)
+				companyRepo.On("IsClientOfCompany", mock.AnythingOfType("domain.CompanyId"), mock.AnythingOfType("domain.ClientId")).Return(true, nil)
+				userRepo.On("FindByUserId", mock.AnythingOfType("domain.UserId")).Return(domain.User{CompanyId: comId}, nil)
+				executor.On("Exec").Return(nil)
+			},
+			want: func() domain.Invoice {
+				return domain.Invoice{}
+			},
+			wantErr: domain.ErrorInvalidPaymentAmount,
+		},
+		{
+			name: "取引先IDが空",
+			args: args{
+				dto: InvoiceCreateDTO{
+					UserId:        "user1",
+					ClientId:      "",
+					PaymentAmount: 10000,
+					DueAt:         now.AddDate(0, 0, 1),
+				},
+			},
+			mock: func(
+				logger *imock.MockLogger,
+				invoiceRepo *imock.MockInvoiceRepository,
+				companyRepo *imock.MockCompanyRepository,
+				userRepo *imock.MockUserRepository,
+				executor *imock.MockExecutor,
+			) {
+				comId, _ := domain.NewCompanyId("company1")
+				logger.On("Error", mock.Anything).Return()
+				invoiceRepo.On("Store", mock.AnythingOfType("domain.Invoice")).Return(nil)
+				companyRepo.On("IsClientOfCompany", mock.AnythingOfType("domain.CompanyId"), mock.AnythingOfType("domain.ClientId")).Return(true, nil)
+				userRepo.On("FindByUserId", mock.AnythingOfType("domain.UserId")).Return(domain.User{CompanyId: comId}, nil)
+				executor.On("Exec").Return(nil)
+			},
+			want: func() domain.Invoice {
+				return domain.Invoice{}
+			},
+			wantErr: domain.ErrorClientIdEmpty,
+		},
+		{
+			name: "ユーザーIDが空",
+			args: args{
+				dto: InvoiceCreateDTO{
+					UserId:        "",
+					ClientId:      "client1",
+					PaymentAmount: 10000,
+					DueAt:         now.AddDate(0, 0, 1),
+				},
+			},
+			mock: func(
+				logger *imock.MockLogger,
+				invoiceRepo *imock.MockInvoiceRepository,
+				companyRepo *imock.MockCompanyRepository,
+				userRepo *imock.MockUserRepository,
+				executor *imock.MockExecutor,
+			) {
+				comId, _ := domain.NewCompanyId("company1")
+				logger.On("Error", mock.Anything).Return()
+				invoiceRepo.On("Store", mock.AnythingOfType("domain.Invoice")).Return(nil)
+				companyRepo.On("IsClientOfCompany", mock.AnythingOfType("domain.CompanyId"), mock.AnythingOfType("domain.ClientId")).Return(true, nil)
+				userRepo.On("FindByUserId", mock.AnythingOfType("domain.UserId")).Return(domain.User{CompanyId: comId}, nil)
+				executor.On("Exec").Return(nil)
+			},
+			want: func() domain.Invoice {
+				return domain.Invoice{}
+			},
+			wantErr: domain.ErrorUserIdEmpty,
+		},
+		{
+			name: "支払い日が過去の日付",
+			args: args{
+				dto: InvoiceCreateDTO{
+					UserId:        "user1",
+					ClientId:      "client1",
+					PaymentAmount: 10000,
+					DueAt:         now.AddDate(0, 0, -1),
+				},
+			},
+			mock: func(
+				logger *imock.MockLogger,
+				invoiceRepo *imock.MockInvoiceRepository,
+				companyRepo *imock.MockCompanyRepository,
+				userRepo *imock.MockUserRepository,
+				executor *imock.MockExecutor,
+			) {
+				comId, _ := domain.NewCompanyId("company1")
+				logger.On("Error", mock.Anything).Return()
+				invoiceRepo.On("Store", mock.AnythingOfType("domain.Invoice")).Return(nil)
+				companyRepo.On("IsClientOfCompany", mock.AnythingOfType("domain.CompanyId"), mock.AnythingOfType("domain.ClientId")).Return(true, nil)
+				userRepo.On("FindByUserId", mock.AnythingOfType("domain.UserId")).Return(domain.User{CompanyId: comId}, nil)
+				executor.On("Exec").Return(nil)
+			},
+			want: func() domain.Invoice {
+				return domain.Invoice{}
+			},
+			wantErr: domain.ErrorDueDateBeforeIssue,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			logger := new(imock.MockLogger)
+			invoiceRepo := new(imock.MockInvoiceRepository)
+			companyRepo := new(imock.MockCompanyRepository)
+			userRepo := new(imock.MockUserRepository)
+			executor := new(imock.MockExecutor)
+			tt.mock(logger, invoiceRepo, companyRepo, userRepo, executor)
+			clientVerificationService := service.NewClientVerificationService(logger, companyRepo, userRepo)
+			uc := NewInvoiceUseCase(logger, invoiceRepo, userRepo, executor, &clientVerificationService)
+
+			got, err := uc.Create(tt.args.dto)
+			expected := tt.want()
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, expected.ClientId, got.ClientId)
+			assert.Equal(t, expected.PaymentAmount, got.PaymentAmount)
+			assert.Equal(t, expected.Fee, got.Fee)
+			assert.Equal(t, expected.Tax, got.Tax)
+			assert.Equal(t, expected.InvoiceAmount, got.InvoiceAmount)
+			assert.Equal(t, expected.DueDate, got.DueDate)
+		})
+	}
+}


### PR DESCRIPTION
## 概要

**請求書発行の一連の流れをUseCaseで実装**
先に作成したクライアント関係を検証するServiceを通して、クライアント関係を検証。
検証後、エンティティやバリューオブジェクトのバリデーションが問題なければ、永続化される。
永続化にはUnitOfWorkを取り入れて作成・変更を一元的に取り扱っている。