### PR TITLE
modelの~ID -> Idへ変更

### DIFF
--- a/internal/payment/infra/converter.go
+++ b/internal/payment/infra/converter.go
@@ -26,11 +26,11 @@ func (invoiceConverter) ToRDBModel(invoice domain.Invoice) rdb.Invoice {
 type userConverter struct{}
 
 func (userConverter) ToEntity(user rdb.User) (domain.User, error) {
-	uId, err := domain.NewUserId(user.UserID)
+	uId, err := domain.NewUserId(user.UserId)
 	if err != nil {
 		return domain.User{}, err
 	}
-	compId, err := domain.NewCompanyId(user.CompanyID)
+	compId, err := domain.NewCompanyId(user.CompanyId)
 	if err != nil {
 		return domain.User{}, err
 	}

--- a/internal/payment/infra/t_rdb_executor_test.go
+++ b/internal/payment/infra/t_rdb_executor_test.go
@@ -50,8 +50,8 @@ func TestExecutorRDB_Append(t *testing.T) {
 			args: args{fnList: []ExecFunc{
 				func(tx *gorm.DB) error {
 					u := rdb.User{
-						UserID:    "user99990",
-						CompanyID: "company99990",
+						UserId:    "user99990",
+						CompanyId: "company99990",
 						Name:      "user99990",
 						Email:     "email1@test.com",
 						Password:  "asdasdasd",
@@ -62,8 +62,8 @@ func TestExecutorRDB_Append(t *testing.T) {
 				},
 				func(tx *gorm.DB) error {
 					u := rdb.User{
-						UserID:    "user99991",
-						CompanyID: "company99991",
+						UserId:    "user99991",
+						CompanyId: "company99991",
 						Name:      "user99991",
 						Email:     "email2@test.com",
 						Password:  "asdasdasd",
@@ -74,8 +74,8 @@ func TestExecutorRDB_Append(t *testing.T) {
 				},
 				func(tx *gorm.DB) error {
 					u := rdb.User{
-						UserID:    "user99993",
-						CompanyID: "company99993",
+						UserId:    "user99993",
+						CompanyId: "company99993",
 						Name:      "user99993",
 						Email:     "email3@test.com",
 						Password:  "asdasdasd",
@@ -115,8 +115,8 @@ func TestExecutorRDB_Exec(t *testing.T) {
 			args: args{fnList: []ExecFunc{
 				func(tx *gorm.DB) error {
 					u := rdb.User{
-						UserID:    "user99990",
-						CompanyID: "company99990",
+						UserId:    "user99990",
+						CompanyId: "company99990",
 						Name:      "user99990",
 						Email:     "email1@test.com",
 						Password:  "asdasdasd",
@@ -127,8 +127,8 @@ func TestExecutorRDB_Exec(t *testing.T) {
 				},
 				func(tx *gorm.DB) error {
 					u := rdb.User{
-						UserID:    "user99991",
-						CompanyID: "company99991",
+						UserId:    "user99991",
+						CompanyId: "company99991",
 						Name:      "user99991",
 						Email:     "email2@test.com",
 						Password:  "asdasdasd",
@@ -139,8 +139,8 @@ func TestExecutorRDB_Exec(t *testing.T) {
 				},
 				func(tx *gorm.DB) error {
 					u := rdb.User{
-						UserID:    "user99993",
-						CompanyID: "company99993",
+						UserId:    "user99993",
+						CompanyId: "company99993",
 						Name:      "user99993",
 						Email:     "email3@test.com",
 						Password:  "asdasdasd",

--- a/internal/rdb/client.go
+++ b/internal/rdb/client.go
@@ -1,6 +1,6 @@
 package rdb
 
 type Client struct {
-	CompanyID string `json:"company_id"`
-	ClientID  string `json:"client_id"`
+	CompanyId string `json:"company_id"`
+	ClientId  string `json:"client_id"`
 }

--- a/internal/rdb/company.go
+++ b/internal/rdb/company.go
@@ -3,7 +3,7 @@ package rdb
 import "time"
 
 type Company struct {
-	CompanyID          string     `json:"company_id"`
+	CompanyId          string     `json:"company_id"`
 	Name               string     `json:"name"`
 	RepresentativeName string     `json:"representative_name"`
 	PhoneNumber        string     `json:"phone_number"`

--- a/internal/rdb/company_bank.go
+++ b/internal/rdb/company_bank.go
@@ -3,8 +3,8 @@ package rdb
 import "time"
 
 type CompanyBank struct {
-	CompanyBankID string     `json:"company_bank_id"`
-	CompanyID     string     `json:"company_id"`
+	CompanyBankId string     `json:"company_bank_id"`
+	CompanyId     string     `json:"company_id"`
 	BankCode      string     `json:"bank_code"`
 	BranchCode    string     `json:"branch_code"`
 	BankName      string     `json:"bank_name"`

--- a/internal/rdb/invoice_status.go
+++ b/internal/rdb/invoice_status.go
@@ -1,6 +1,6 @@
 package rdb
 
 type InvoiceStatus struct {
-	StatusID   int    `json:"status_id"`
+	StatusId   int    `json:"status_id"`
 	StatusName string `json:"status_name"`
 }

--- a/internal/rdb/user.go
+++ b/internal/rdb/user.go
@@ -3,8 +3,8 @@ package rdb
 import "time"
 
 type User struct {
-	UserID    string     `json:"user_id"`
-	CompanyID string     `json:"company_id"`
+	UserId    string     `json:"user_id"`
+	CompanyId string     `json:"company_id"`
 	Name      string     `json:"name"`
 	Email     string     `json:"email"`
 	Password  string     `json:"password"`


### PR DESCRIPTION
## 概要

RDBのテーブルと対になるモデルの〜IDを~Idへ変更
全てのコードで"Id"に統一するため